### PR TITLE
Small HTTPRequest fix

### DIFF
--- a/lib/concurrence/http/__init__.py
+++ b/lib/concurrence/http/__init__.py
@@ -25,7 +25,7 @@ class HTTPRequest(object):
     def _set_body(self, body):
         if body is not None:
             assert type(body) == str
-            self.add_header('Content_length', len(body))
+            self.add_header('Content-length', len(body))
         self._body = body
 
     def _get_body(self):


### PR DESCRIPTION
Hi,

For a project I created a Transport for xmlrpclib based on the concurrence HTTPConnection.
This gave us a 3x performance boost for our xmlrpc clients compared to socket monkey patching.

On my way I found a small issue with the HTTPRequest object, the server side (twisted) didn't like the 'Content_length' header.

Kind regards,

Kurt
